### PR TITLE
Fix deprecated poetry.dev-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{include = "worklog"}]
 python = "^3.12"
 PyGObject = "*"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^8.0"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
## Summary
- update pyproject to use `[tool.poetry.group.dev.dependencies]`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68764ebb100c83218b20ea49650c1ddc