### PR TITLE
Fix UserStore token default

### DIFF
--- a/worklog/stores/user_store.py
+++ b/worklog/stores/user_store.py
@@ -22,6 +22,10 @@ if GI_AVAILABLE:
     class UserStore(GObject.Object):  # pragma: no cover - Gtk specific
         token = GObject.Property(type=str, default=None)
 
+        def __init__(self) -> None:
+            super().__init__()
+            self.token = None
+
         def load_credentials(self) -> None:
             """Load credentials from configuration."""
             pass


### PR DESCRIPTION
## Summary
- ensure `token` property defaults to `None` even when PyGObject is available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68764ed356348321a20b3fca856aaf30