### PR TITLE
Fix header bar creation for GTK4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/

--- a/worklog/ui/login_window.py
+++ b/worklog/ui/login_window.py
@@ -22,7 +22,10 @@ if GTK_AVAILABLE:
             self.set_default_size(400, 200)
 
             # Header bar
-            header = Gtk.HeaderBar(title="Worklog • Sign in", show_close_button=True)
+            header = Gtk.HeaderBar()
+            header.set_show_close_button(True)
+            title_label = Gtk.Label(label="Worklog • Sign in")
+            header.set_title_widget(title_label)
             self.set_titlebar(header)
 
             # Content area

--- a/worklog/ui/main_window.py
+++ b/worklog/ui/main_window.py
@@ -22,7 +22,10 @@ if GTK_AVAILABLE:
             self.set_default_size(800, 600)
 
             # Header bar with simple toolbar
-            header = Gtk.HeaderBar(title="Worklog", show_close_button=True)
+            header = Gtk.HeaderBar()
+            header.set_show_close_button(True)
+            title_label = Gtk.Label(label="Worklog")
+            header.set_title_widget(title_label)
             menu_btn = Gtk.Button.new_from_icon_name("open-menu-symbolic")
             search_entry = Gtk.SearchEntry()
             refresh_btn = Gtk.Button.new_from_icon_name("view-refresh-symbolic")


### PR DESCRIPTION
## Summary
- adjust Gtk.HeaderBar usage to support GTK4
- ignore Python cache files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687670e40270832196c412b887e295d5