### PR TITLE
Fix Firebase auth config and refresh

### DIFF
--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -9,12 +9,14 @@ from worklog.stores.user_store import UserStore
 
 
 def test_user_store_token_default():
+    os.environ["WORKLOG_FB_API_KEY"] = "testkey"
     store = UserStore()
     assert getattr(store, "token", None) is None
 
 
 def test_sign_in_persists_credentials(monkeypatch, tmp_path):
     monkeypatch.setattr(user_store.Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("WORKLOG_FB_API_KEY", "testkey")
     store = UserStore()
     store.sign_in("id1", "refresh1")
     assert store.token == "id1"
@@ -28,3 +30,24 @@ def test_sign_in_persists_credentials(monkeypatch, tmp_path):
 
     store2.sign_out()
     assert not path.exists()
+
+
+def test_refresh_adds_api_key(monkeypatch, tmp_path):
+    monkeypatch.setattr(user_store.Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("WORKLOG_FB_API_KEY", "dummy")
+    store = UserStore()
+    store.refresh_token = "r1"
+
+    captured = {}
+
+    class DummyResp:
+        def read(self):
+            return b'{"id_token": "tid"}'
+
+    def fake_urlopen(req, timeout=10):
+        captured['url'] = req.full_url
+        return DummyResp()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    store.refresh_id_token()
+    assert captured['url'].endswith("?key=dummy")

--- a/worklog/auth/firebase.py
+++ b/worklog/auth/firebase.py
@@ -1,0 +1,38 @@
+import json
+import os
+from pathlib import Path
+from typing import Dict
+
+
+_CONFIG_PATH = Path.home() / ".config" / "worklog" / "firebase_config.json"
+
+
+def load_firebase_config() -> Dict[str, str]:
+    """Load Firebase project configuration.
+
+    The configuration is read from ``~/.config/worklog/firebase_config.json`` if
+    present. Otherwise environment variables prefixed with ``WORKLOG_FB_`` are
+    used. At minimum, ``apiKey`` must be provided.  Raises ``RuntimeError`` if
+    the configuration cannot be found.
+    """
+    if _CONFIG_PATH.exists():
+        try:
+            with _CONFIG_PATH.open("r", encoding="utf-8") as fh:
+                cfg = json.load(fh)
+            if "apiKey" in cfg:
+                return cfg
+        except Exception:
+            pass
+    # Fallback to environment variables
+    api_key = os.getenv("WORKLOG_FB_API_KEY")
+    if api_key:
+        cfg = {"apiKey": api_key}
+        client_id = os.getenv("WORKLOG_FB_CLIENT_ID")
+        project_id = os.getenv("WORKLOG_FB_PROJECT_ID")
+        if client_id:
+            cfg["clientId"] = client_id
+        if project_id:
+            cfg["projectId"] = project_id
+        return cfg
+
+    raise RuntimeError("Firebase configuration missing")

--- a/worklog/stores/user_store.py
+++ b/worklog/stores/user_store.py
@@ -21,6 +21,8 @@ import json
 from pathlib import Path
 from typing import Dict, Optional
 
+from ..auth.firebase import load_firebase_config
+
 _ENC_KEY = b"worklog"
 
 
@@ -67,6 +69,7 @@ if GI_AVAILABLE:
             self.token: str | None = None
             self.refresh_token: str | None = None
             self._cred_path = _get_cred_path()
+            self._firebase_cfg = load_firebase_config()
             self.load_credentials()
 
         # ── Public API ────────────────────────────────────────────────
@@ -101,8 +104,12 @@ if GI_AVAILABLE:
                     "refresh_token": self.refresh_token,
                 }
             ).encode()
+            url = (
+                "https://securetoken.googleapis.com/v1/token?key="
+                + self._firebase_cfg["apiKey"]
+            )
             req = request.Request(
-                "https://securetoken.googleapis.com/v1/token",
+                url,
                 data=data,
                 method="POST",
             )
@@ -128,6 +135,7 @@ else:
             self.token: str | None = None
             self.refresh_token: str | None = None
             self._cred_path = _get_cred_path()
+            self._firebase_cfg = load_firebase_config()
             self.load_credentials()
 
         def load_credentials(self) -> None:  # pragma: no cover - placeholder
@@ -158,8 +166,12 @@ else:
                     "refresh_token": self.refresh_token,
                 }
             ).encode()
+            url = (
+                "https://securetoken.googleapis.com/v1/token?key="
+                + self._firebase_cfg["apiKey"]
+            )
             req = request.Request(
-                "https://securetoken.googleapis.com/v1/token",
+                url,
                 data=data,
                 method="POST",
             )

--- a/worklog/ui/login_window.py
+++ b/worklog/ui/login_window.py
@@ -45,7 +45,20 @@ if GTK_AVAILABLE:
 
         def on_google(self, _button: Gtk.Button) -> None:
             import webbrowser
-            webbrowser.open("https://accounts.google.com/o/oauth2/v2/auth")
+            from ..auth.firebase import load_firebase_config
+
+            cfg = load_firebase_config()
+            client_id = cfg.get("clientId")
+            if not client_id:
+                raise RuntimeError("Firebase client ID missing")
+
+            url = (
+                "https://accounts.google.com/o/oauth2/v2/auth?"
+                f"client_id={client_id}&"
+                "response_type=code&scope=openid%20email%20profile&"
+                "redirect_uri=worklog://auth"
+            )
+            webbrowser.open(url)
 else:
 
     class LoginWindow:  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- support firebase project configuration via file/env vars
- include API key in token refresh
- launch Google OAuth with configured client id
- test refresh uses API key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877180aa538832195d8ded1a57f4c39