### PR TITLE
Load auth config from ~/.config

### DIFF
--- a/tests/test_google_oauth.py
+++ b/tests/test_google_oauth.py
@@ -1,0 +1,26 @@
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from worklog.auth import firebase
+
+
+def test_load_google_oauth_from_file(tmp_path, monkeypatch):
+    d = tmp_path / ".config" / "worklog"
+    d.mkdir(parents=True)
+    content = {"installed": {"client_id": "abc", "redirect_uris": ["http://localhost"]}}
+    path = d / "google_oauth_client.json"
+    path.write_text(json.dumps(content))
+    monkeypatch.setattr(firebase, "_GOOGLE_OAUTH_PATH", path)
+    cfg = firebase.load_google_oauth_client()
+    assert cfg["client_id"] == "abc"
+
+
+def test_load_google_oauth_from_env(tmp_path, monkeypatch):
+    monkeypatch.delenv("WORKLOG_GOOGLE_CLIENT_ID", raising=False)
+    monkeypatch.setenv("WORKLOG_GOOGLE_CLIENT_ID", "xyz")
+    monkeypatch.setattr(firebase, "_GOOGLE_OAUTH_PATH", tmp_path / "doesntexist.json")
+    cfg = firebase.load_google_oauth_client()
+    assert cfg["client_id"] == "xyz"

--- a/worklog/auth/firebase.py
+++ b/worklog/auth/firebase.py
@@ -5,6 +5,7 @@ from typing import Dict
 
 
 _CONFIG_PATH = Path.home() / ".config" / "worklog" / "firebase_config.json"
+_GOOGLE_OAUTH_PATH = Path.home() / ".config" / "worklog" / "google_oauth_client.json"
 
 
 def load_firebase_config() -> Dict[str, str]:
@@ -36,3 +37,27 @@ def load_firebase_config() -> Dict[str, str]:
         return cfg
 
     raise RuntimeError("Firebase configuration missing")
+
+
+def load_google_oauth_client() -> Dict[str, str]:
+    """Load Google OAuth client configuration for the desktop app.
+
+    Looks for ``~/.config/worklog/google_oauth_client.json`` which should be the
+    "installed" JSON downloaded from Google Cloud. If the file is absent,
+    ``WORKLOG_GOOGLE_CLIENT_ID`` environment variable is used.  At minimum,
+    ``client_id`` must be provided.
+    """
+    if _GOOGLE_OAUTH_PATH.exists():
+        try:
+            with _GOOGLE_OAUTH_PATH.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            if "installed" in data:
+                data = data["installed"]
+            if "client_id" in data:
+                return data
+        except Exception:
+            pass
+    client_id = os.getenv("WORKLOG_GOOGLE_CLIENT_ID")
+    if client_id:
+        return {"client_id": client_id}
+    raise RuntimeError("Google OAuth client configuration missing")

--- a/worklog/ui/login_window.py
+++ b/worklog/ui/login_window.py
@@ -45,12 +45,12 @@ if GTK_AVAILABLE:
 
         def on_google(self, _button: Gtk.Button) -> None:
             import webbrowser
-            from ..auth.firebase import load_firebase_config
+            from ..auth.firebase import load_google_oauth_client
 
-            cfg = load_firebase_config()
-            client_id = cfg.get("clientId")
+            cfg = load_google_oauth_client()
+            client_id = cfg.get("client_id")
             if not client_id:
-                raise RuntimeError("Firebase client ID missing")
+                raise RuntimeError("Google OAuth client ID missing")
 
             url = (
                 "https://accounts.google.com/o/oauth2/v2/auth?"


### PR DESCRIPTION
## Summary
- add `load_google_oauth_client` helper
- update login window to use new OAuth config loader
- expect google_oauth_client.json and firebase_config.json in `~/.config/worklog`
- document config files in SPEC
- cover new helper with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68772fc4ee548321acbfe8c879fbb736