### PR TITLE
Fix OAuth scope and window

### DIFF
--- a/worklog/auth/google.py
+++ b/worklog/auth/google.py
@@ -29,7 +29,12 @@ from typing import Tuple
 import requests
 
 # Scopes required to receive an ID token that includes the user's identity.
-SCOPES = ["openid", "email", "profile"]
+# Use the canonical userinfo scope URIs to avoid scope mismatch warnings.
+SCOPES = [
+    "openid",
+    "https://www.googleapis.com/auth/userinfo.email",
+    "https://www.googleapis.com/auth/userinfo.profile",
+]
 
 # Location where the user should drop the downloaded *Desktop app* client JSON.
 _GOOGLE_OAUTH_PATH = Path.home() / ".config" / "worklog" / "google_oauth_client.json"

--- a/worklog/ui/login_window.py
+++ b/worklog/ui/login_window.py
@@ -14,7 +14,7 @@ except Exception:  # pragma: no cover - gi not installed
 
 if GTK_AVAILABLE:
 
-    class LoginWindow(Adw.ApplicationWindow):  # pragma: no cover - UI code
+    class LoginWindow(Gtk.ApplicationWindow):  # pragma: no cover - UI code
         """Simple login window with Google sign-in only."""
 
         def __init__(self, **kwargs):
@@ -46,7 +46,7 @@ if GTK_AVAILABLE:
             btn_box.append(google_btn)
             box.append(btn_box)
 
-            self.set_content(box)
+            self.set_child(box)
 
         def on_google(self, _button: Gtk.Button) -> None:  # pragma: no cover - UI code
             """Run Google OAuth → exchange for Firebase → sign in."""


### PR DESCRIPTION
## Summary
- use canonical userinfo scopes in OAuth helper
- base `LoginWindow` on `Gtk.ApplicationWindow`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68775ac102b08321b1f04baeec9d77ff