### PR TITLE
Fix log list not refreshing when reopening main window

### DIFF
--- a/worklog/app.py
+++ b/worklog/app.py
@@ -39,6 +39,9 @@ if GTK_AVAILABLE:
                 if self.main_window is None:
                     from .ui.main_window import MainWindow
                     self.main_window = MainWindow(self.user_store, application=self)
+                else:
+                    if hasattr(self.main_window, "refresh"):
+                        self.main_window.refresh()
                 self.main_window.present()
 
 else:


### PR DESCRIPTION
## Summary
- refresh the log list every time the application is activated

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ccfc29748321a74e3d0b63a94458