### PR TITLE
Adjust FlowBox grid for responsive columns

### DIFF
--- a/worklog/ui/day_card.py
+++ b/worklog/ui/day_card.py
@@ -58,6 +58,7 @@ if Gtk:
     class DayCard(Gtk.FlowBoxChild):  # pragma: no cover - pure UI glue
         def __init__(self, date_obj: _dt.date, logs: Iterable[Mapping[str, Any]]) -> None:
             super().__init__()
+            self.set_size_request(220, -1)
 
             frame = Gtk.Frame()
             frame.add_css_class("day-card")

--- a/worklog/ui/main_window.py
+++ b/worklog/ui/main_window.py
@@ -97,6 +97,7 @@ if GTK_AVAILABLE:
             self._flow = Gtk.FlowBox()
             self._flow.set_valign(Gtk.Align.START)
             self._flow.set_selection_mode(Gtk.SelectionMode.NONE)
+            self._flow.set_min_children_per_line(1)
             self._flow.set_max_children_per_line(4)
             self._flow.set_row_spacing(12)
             self._flow.set_column_spacing(12)

--- a/worklog/ui/style.css
+++ b/worklog/ui/style.css
@@ -5,6 +5,8 @@
   margin: 4px;
   border: 1px solid alpha(@theme_fg_color, 0.10);
   background-color: alpha(@theme_fg_color, 0.04);
+  min-width: 220px;
+  max-width: 220px;
 }
 
 .day-card-header {


### PR DESCRIPTION
## Summary
- tweak FlowBox so columns grow from one up to four depending on width
- constrain day card width so up to four columns fit on wide screens

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878a832e5b883219aa7d75ab3a46edf